### PR TITLE
Fix: Update README.md to use gen1 Cloud Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Enable Google Artifact Registry, a dedicated type of storage which we will confi
 
 And now we will deploy a single _function_ from our application, the function `index()` found in the file `api/hello_cloud.py`: 
 
-`gcloud functions deploy hello_cloud --runtime python311 --trigger-http --allow-unauthenticated --max-instances 2 --set-build-env-vars=GOOGLE_FUNCTION_SOURCE=api/hello_cloud.py --region=europe-west3 --docker-registry=artifact-registry`
+`gcloud functions deploy hello_cloud --no-gen2 --runtime python311 --trigger-http --allow-unauthenticated --max-instances 2 --set-build-env-vars=GOOGLE_FUNCTION_SOURCE=api/hello_cloud.py --region=europe-west3 --docker-registry=artifact-registry`
 
 This reads as: "Hey Google, deploy a Cloud Function for me called hello_cloud, which is both the name of the function that I've defined as well as the name that you'll use to identify the function. That function is in the file api/hello_cloud.py, which you can build into some executable stored in the artifact registry. It should use the Python 3.11 runtime, anyone can access it on the internet without authentication, but only allow 2 instance to not run up my bill. Run the function if there is an HTTP request to the URL. ". 
 


### PR DESCRIPTION
> The section (https://github.com/DrAdamRoe/cloud-variations?tab=readme-ov-file#variation-functions-as-a-service) needs the following flag, since generation 2 Functions do not seem to support some Cloud Source Repository configs (See: https://issuetracker.google.com/issues/248110968?pli=1):

`--no-gen2`